### PR TITLE
[fix] 상세페이지 이미지 없을 시 기본 화면 노출

### DIFF
--- a/src/components/posts/PostList.jsx
+++ b/src/components/posts/PostList.jsx
@@ -143,9 +143,19 @@ const PostList = ({ isMyPage }) => {
                       </div>
 
                       <div className="image">
-                        <img src={post.img_url} alt="" />
+                        {post.img_url ? (
+                          <img src={post.img_url} alt="Post" />
+                        ) : (
+                          <div className="noImageWrap">
+                            <div className="noImageEN">
+                              <p>NO IMAGE</p>
+                            </div>
+                            <div className="noImageKR">
+                              <p>이미지가 없습니다.</p>
+                            </div>
+                          </div>
+                        )}
                       </div>
-
                       <div className="context">{post.context}</div>
                     </div>
 
@@ -202,7 +212,7 @@ const ObserverArea = styled.div`
 
 const StyledPostList = styled.ul`
   display: flex;
-  flex-direction: row;  
+  flex-direction: row;
   justify-content: ${({ $isView }) => {
     if ($isView === false) {
       return "center";

--- a/src/pages/Board.jsx
+++ b/src/pages/Board.jsx
@@ -85,7 +85,14 @@ const Board = () => {
               {foundPost.img_url ? (
                 <img src={foundPost.img_url} alt="Post" />
               ) : (
-                <div className="noImageWrap">이미지가 없습니다.</div>
+                <div className="noImageWrap">
+                  <div className="noImageEN">
+                    <p>NO IMAGE</p>
+                  </div>
+                  <div className="noImageKR">
+                    <p>이미지가 없습니다.</p>
+                  </div>
+                </div>
               )}
             </div>
 

--- a/src/styles/BoardStyle.js
+++ b/src/styles/BoardStyle.js
@@ -75,8 +75,10 @@ export const BoardContainer = styled.div`
     }
 
     .noImageWrap {
+      color: #888888;
+      font-weight: bold;
       height: 100%;
-      background-color: lightgray;
+      background-image: linear-gradient(145deg, rgba(245, 245, 245, 0.9), #ffd9b9);
       display: flex;
       flex-direction: column;
       justify-content: center;


### PR DESCRIPTION
## 💁🏻‍♀️ 작업

- 기본 이미지 작업

<br>

## 🔥 작업 세부 내용

- 게시글 이미지를 등록 안 했을 때 기본 화면이 보이도록 적용

<br>

## 🚫 참고 사항

- 관련된 이슈나 참고할 사항을 적어주세요.
